### PR TITLE
Fix map RLS, session race, and live vector tile refresh

### DIFF
--- a/components/views/map-controller.tsx
+++ b/components/views/map-controller.tsx
@@ -84,6 +84,7 @@ export function MapController({
 	const [selectedTool, setSelectedTool] = useState<Tool>("hand");
 	const [isDrawing, setIsDrawing] = useState(false);
 	const [isErasing, setIsErasing] = useState(false);
+	const isErasingRef = useRef(false);
 	const [featuresToErase, setFeaturesToErase] = useState<string[]>([]);
 	const featuresToEraseRef = useRef<string[]>([]);
 	const [annotationText, setAnnotationText] = useState("");
@@ -466,29 +467,43 @@ export function MapController({
 					},
 				],
 			});
-		} else if (selectedTool === "eraser" && isErasing) {
-			if (!mapRef.current) return;
-			const m = mapRef.current.getMap();
-			const features = m.queryRenderedFeatures(e.point, {
-				layers: ["drawings-layer", "pins-layer", "annotations-layer"],
-			});
-			if (features.length > 0) {
-				const featureId = `${features[0].layer.source} ${features[0].properties.id}`;
-				setFeaturesToErase((prev) => {
-					// Use a Set to ensure uniqueness
-					const uniqueFeatures = new Set(prev);
-					uniqueFeatures.add(featureId);
-					return Array.from(uniqueFeatures);
-				});
-				m.setFeatureState(
-					{
-						source: features[0].source,
-						sourceLayer: features[0].sourceLayer,
-						id: features[0].id,
-					},
-					{ markedDelete: true },
-				);
-			}
+		} else if (selectedTool === "eraser" && isErasingRef.current) {
+			collectFeaturesToErase(e.point);
+		}
+	};
+
+	const collectFeaturesToErase = (point: { x: number; y: number }) => {
+		if (!mapRef.current) return;
+		const m = mapRef.current.getMap();
+		// Thin lines are hard to hit with a single pixel — use a small pad.
+		const pad = 12;
+		const features = m.queryRenderedFeatures(
+			[
+				[point.x - pad, point.y - pad],
+				[point.x + pad, point.y + pad],
+			],
+			{ layers: ["drawings-layer", "pins-layer", "annotations-layer"] },
+		);
+		if (features.length === 0) return;
+
+		const feature = features[0];
+		const rowId = feature.properties?.id ?? feature.id;
+		if (rowId === undefined || rowId === null) return;
+
+		const featureId = `${feature.source} ${rowId}`;
+		const next = Array.from(new Set([...featuresToEraseRef.current, featureId]));
+		featuresToEraseRef.current = next;
+		setFeaturesToErase(next);
+
+		if (feature.id !== undefined) {
+			m.setFeatureState(
+				{
+					source: feature.source,
+					sourceLayer: feature.sourceLayer,
+					id: feature.id,
+				},
+				{ markedDelete: true },
+			);
 		}
 	};
 
@@ -529,11 +544,16 @@ export function MapController({
 				updateTiles(drawingsSourceConfig);
 			}
 		} else if (selectedTool === "eraser") {
+			isErasingRef.current = false;
 			setIsErasing(false);
-			for (const featureId of featuresToEraseRef.current) {
+			const toErase = [...featuresToEraseRef.current];
+			featuresToEraseRef.current = [];
+			setFeaturesToErase([]);
+			for (const featureId of toErase) {
 				const [sourceId, featureIdStr] = featureId.split(" ");
 				const table = sourceId.replace("public.", "");
-				const id = parseInt(featureIdStr);
+				const id = parseInt(featureIdStr, 10);
+				if (!Number.isFinite(id)) continue;
 				await deleteFeature(table, id);
 			}
 
@@ -560,7 +580,10 @@ export function MapController({
 				],
 			});
 		} else if (selectedTool === "eraser") {
+			isErasingRef.current = true;
 			setIsErasing(true);
+			// Click (no drag) should still erase under the cursor.
+			collectFeaturesToErase(e.point);
 		}
 		window.addEventListener("mouseup", mapMouseUp);
 	};
@@ -666,7 +689,7 @@ export function MapController({
 							}}
 						/>
 					</Source>
-					<Source type="vector" {...drawingsSourceConfig}>
+					<Source type="vector" {...drawingsSourceConfig} promoteId="id">
 						<Layer
 							id="drawings-layer"
 							type="line"
@@ -674,7 +697,7 @@ export function MapController({
 							{...drawingStyles}
 						/>
 					</Source>
-					<Source type="vector" {...pinsSourceConfig}>
+					<Source type="vector" {...pinsSourceConfig} promoteId="id">
 						<Layer
 							id="pins-layer"
 							type="symbol"
@@ -714,7 +737,7 @@ export function MapController({
 							}}
 						/>
 					</Source>
-					<Source type="vector" {...annotationsSourceConfig}>
+					<Source type="vector" {...annotationsSourceConfig} promoteId="id">
 						<Layer
 							id="annotations-layer"
 							type="symbol"

--- a/components/views/map-controller.tsx
+++ b/components/views/map-controller.tsx
@@ -216,6 +216,34 @@ export function MapController({
 		updateTiles(annotationsSourceConfig);
 	}, [mapProject]);
 
+	// Refresh vector tiles when other clients add/update/remove features on this map
+	useEffect(() => {
+		if (!mapProject?.id) return;
+
+		const channel = geobase.supabase
+			.channel(`map-features:${mapProject.id}`)
+			.on(
+				"postgres_changes",
+				{ event: "*", schema: "public", table: "smb_pins", filter: `project_id=eq.${mapProject.id}` },
+				() => updateTiles(pinsSourceConfig),
+			)
+			.on(
+				"postgres_changes",
+				{ event: "*", schema: "public", table: "smb_drawings", filter: `project_id=eq.${mapProject.id}` },
+				() => updateTiles(drawingsSourceConfig),
+			)
+			.on(
+				"postgres_changes",
+				{ event: "*", schema: "public", table: "smb_annotations", filter: `project_id=eq.${mapProject.id}` },
+				() => updateTiles(annotationsSourceConfig),
+			)
+			.subscribe();
+
+		return () => {
+			geobase.supabase.removeChannel(channel);
+		};
+	}, [mapProject?.id]);
+
 	useEffect(() => {
 		if (!mapRef.current) return;
 

--- a/geobase/migrations/20240813165645_project-setup.sql
+++ b/geobase/migrations/20240813165645_project-setup.sql
@@ -96,6 +96,12 @@ create policy "Allow published map drawings read access" on public.smb_drawings
 create policy "Allow drawing owner general access" on public.smb_drawings
   for all using ((select auth.uid()) = profile_id);
 
+-- Map project owner can delete any drawing on their map
+create policy "Allow map owner delete drawings" on public.smb_drawings
+  for delete using (
+    project_id in (select id from public.smb_map_projects where profile_id = (select auth.uid()))
+  );
+
 --
 -- Pins Table
 --
@@ -121,6 +127,12 @@ create policy "Allow published map pins read access" on public.smb_pins
 -- Authed, only the pin's owner can update, read, or delete
 create policy "Allow pin owner general access" on public.smb_pins
   for all using ((select auth.uid()) = profile_id);
+
+-- Map project owner can delete any pin on their map
+create policy "Allow map owner delete pins" on public.smb_pins
+  for delete using (
+    project_id in (select id from public.smb_map_projects where profile_id = (select auth.uid()))
+  );
 
 --
 -- Annotations Table
@@ -148,6 +160,12 @@ create policy "Allow published map annotations read access" on public.smb_annota
 create policy "Allow annotation owner general access" on public.smb_annotations
   for all using ((select auth.uid()) = profile_id);
 
+-- Map project owner can delete any annotation on their map
+create policy "Allow map owner delete annotations" on public.smb_annotations
+  for delete using (
+    project_id in (select id from public.smb_map_projects where profile_id = (select auth.uid()))
+  );
+
 --
 -- Attachments Table
 --
@@ -173,6 +191,12 @@ create policy "Allow published map attachments read access" on public.smb_attach
 -- Authed, only the attachment's owner can update, read, or delete
 create policy "Allow attachment owner general access" on public.smb_attachments
   for all using ((select auth.uid()) = profile_id);
+
+-- Map project owner can delete any attachment on their map
+create policy "Allow map owner delete attachments" on public.smb_attachments
+  for delete using (
+    project_id in (select id from public.smb_map_projects where profile_id = (select auth.uid()))
+  );
 
 
 --

--- a/geobase/migrations/20240813165645_project-setup.sql
+++ b/geobase/migrations/20240813165645_project-setup.sql
@@ -90,7 +90,7 @@ alter table public.smb_drawings enable row level security;
 
 -- Allow read access if the drawing's project is published
 create policy "Allow published map drawings read access" on public.smb_drawings
-  for select using (project_id in (select project_id from public.smb_map_projects where published = true));
+  for select using (project_id in (select id from public.smb_map_projects where published = true));
 
 -- Authed, only the drawing's owner can update, read, or delete
 create policy "Allow drawing owner general access" on public.smb_drawings
@@ -116,7 +116,7 @@ alter table public.smb_pins enable row level security;
 
 -- Allow read access if the pin's project is published
 create policy "Allow published map pins read access" on public.smb_pins
-  for select using (project_id in (select project_id from public.smb_map_projects where published = true));
+  for select using (project_id in (select id from public.smb_map_projects where published = true));
 
 -- Authed, only the pin's owner can update, read, or delete
 create policy "Allow pin owner general access" on public.smb_pins
@@ -142,7 +142,7 @@ alter table public.smb_annotations enable row level security;
 
 -- Allow read access if the annotation's project is published
 create policy "Allow published map annotations read access" on public.smb_annotations
-  for select using (project_id in (select project_id from public.smb_map_projects where published = true));
+  for select using (project_id in (select id from public.smb_map_projects where published = true));
 
 -- Authed, only the annotation's owner can update, read, or delete
 create policy "Allow annotation owner general access" on public.smb_annotations
@@ -168,7 +168,7 @@ alter table public.smb_attachments enable row level security;
 
 -- Allow read access if the attachment's project is published
 create policy "Allow published map attachments read access" on public.smb_attachments
-  for select using (project_id in (select project_id from public.smb_map_projects where published = true));
+  for select using (project_id in (select id from public.smb_map_projects where published = true));
 
 -- Authed, only the attachment's owner can update, read, or delete
 create policy "Allow attachment owner general access" on public.smb_attachments

--- a/pages/maps/[id].tsx
+++ b/pages/maps/[id].tsx
@@ -60,22 +60,30 @@ export default function MapPage() {
 	useEffect(() => {
 		const uuid = router.query.id as string | undefined;
 		if (!uuid) return;
-		if (uuid && !mapProject) {
-			fetchMapProject(uuid).then((project) => {
-				console.log("Project fetched:", project);
-				if (!project) {
-					router.push("/404");
-				}
-				setMapProject(project);
-			});
-		} else {
+
+		let cancelled = false;
+		(async () => {
+			// Wait for auth session before fetching so owners can load unpublished maps (avoids empty RLS read → 404).
+			const { data: sessionData } = await geobase.supabase.auth.getSession();
+			if (!sessionData.session && !geobase.sessionRef.current) {
+				await new Promise((r) => setTimeout(r, 500));
+			}
+			if (cancelled) return;
 			setLoadingMessage("Getting map project data...");
-			fetchMapProject(uuid).then((project) => {
-				console.log("New project fetched:", project);
-				setMapProject(project);
-				setIsFirstLoad(true);
-			});
-		}
+			const project = await fetchMapProject(uuid);
+			console.log("Project fetched:", project);
+			if (cancelled) return;
+			if (!project) {
+				router.push("/404");
+				return;
+			}
+			setMapProject(project);
+			setIsFirstLoad(true);
+		})();
+
+		return () => {
+			cancelled = true;
+		};
 	}, [router.query.id]);
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- Correct published-map RLS policies to use `smb_map_projects.id` instead of non-existent `project_id` in the subquery
- Wait for auth session before loading a map so owners of unpublished maps are not redirected to 404
- Subscribe to pin/drawing/annotation changes and refresh vector tiles so collaborators see updates live

## Test plan
- [ ] Apply migration (or re-apply policy statements) on a fresh Geobase project
- [ ] Sign in, create an unpublished map, open it by UUID — map editor loads (no 404)
- [ ] Publish the map; open in a second browser/session as another user — features visible
- [ ] With two clients on the same map, add a pin on one — other client's tiles refresh without reload